### PR TITLE
Add support for timeout using perl and add curl as testing resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ wait-for-it.sh host:port [-s] [-t timeout] [-- command args]
 -h HOST | --host=HOST       Host or IP under test
 -p PORT | --port=PORT       TCP port under test
                             Alternatively, you specify the host and port as host:port
+-c ENDPOINT | --curl=ENDPOINT
+                            Endpoint to curl: if provided, host and port ignored
 -s | --strict               Only execute subcommand if the test succeeds
 -q | --quiet                Don't output any status messages
 -t TIMEOUT | --timeout=TIMEOUT
@@ -26,6 +28,15 @@ For example, let's test to see if we can access port 80 on www.google.com, and i
 
 ```
 $ ./wait-for-it.sh www.google.com:80 -- echo "google is up"
+wait-for-it.sh: waiting 15 seconds for www.google.com:80
+wait-for-it.sh: www.google.com:80 is available after 0 seconds
+google is up
+```
+
+We can test to see if we can access port 80 on www.google.com via curl as well
+
+```
+$ ./wait-for-it.sh -c www.google.com:80 -- echo "google is up"
 wait-for-it.sh: waiting 15 seconds for www.google.com:80
 wait-for-it.sh: www.google.com:80 is available after 0 seconds
 google is up


### PR DESCRIPTION
Perl is used if timeout script does not exist

Curl parameter overrides the host and port provided. Added because host and port were responsive for service in docker container but service was not fully operational, causing chef to fail.