### PR TITLE
add external healthcheck capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ wait-for-it.sh host:port [-s] [-t timeout] [-- command args]
                             Alternatively, you specify the host and port as host:port
 -s | --strict               Only execute subcommand if the test succeeds
 -q | --quiet                Don't output any status messages
+--arg=NAME VALUE            Define arbitrary environment var <NAME> = VALUE
+--check HEALTH-CHECK-ARG    External health check definition (multiple --check allowed)
 -t TIMEOUT | --timeout=TIMEOUT
                             Timeout in seconds, zero for no timeout
 -- COMMAND ARGS             Execute command with args after the test finishes
@@ -68,6 +70,25 @@ wait-for-it.sh: waiting 15 seconds for www.google.com:81
 wait-for-it.sh: timeout occurred after waiting 15 seconds for www.google.com:81
 $ echo $?
 124
+```
+
+### External Health Checks
+
+If you have a need to violate the purity of the bash-only solution, you can use the `--check` argument to build up a command line that will be used to check service availability.
+
+```
+./wait-for-it.sh --check 'nc -z $$HOST $$PORT' -c "echo" -c "google is up"
+```
+
+This can be extended into Docker containers via ENTRYPOINT/CMD settings, and provide a structure for defining a generalized healthcheck and allowing container-specific customizations via the CMD overrides.
+
+### Custom Environment Vars
+
+To help support configuration flexibility with custom healthcheck commands, definition of arbitrary environment vars on the ocmmand line is supported.
+This provides a way to define an argument to the healthcheck command from the command line and reduces complexity of external definition of environment variables.
+
+```
+./wait-for-it.sh --arg=HOSTNAME www.google.com --check 'nc -z $HOSTNAME $PORT' -c "echo" -c "google is up"
 ```
 
 ## Thanks

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 #   Use this script to test if a given TCP host/port are available
 
+HEALTHCHECK_DEFAULT='echo > /dev/tcp/$HOST/$PORT'
+
 cmdname=$(basename $0)
 
 echoerr() { if [[ $QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
@@ -15,6 +17,8 @@ Usage:
                                 Alternatively, you specify the host and port as host:port
     -s | --strict               Only execute subcommand if the test succeeds
     -q | --quiet                Don't output any status messages
+    --arg=NAME VALUE            Define arbitrary environment var <NAME> = VALUE
+    --check HEALTH-CHECK-ARG    External health check definition (multiple --check allowed)
     -t TIMEOUT | --timeout=TIMEOUT
                                 Timeout in seconds, zero for no timeout
     -- COMMAND ARGS             Execute command with args after the test finishes
@@ -24,19 +28,20 @@ USAGE
 
 wait_for()
 {
+    check=${HEALTHCHECK:-$HEALTHCHECK_DEFAULT}
     if [[ $TIMEOUT -gt 0 ]]; then
-        echoerr "$cmdname: waiting $TIMEOUT seconds for $HOST:$PORT"
+        echoerr "$cmdname: waiting $TIMEOUT seconds using [$check ($arglist)]"
     else
-        echoerr "$cmdname: waiting for $HOST:$PORT without a timeout"
+        echoerr "$cmdname: waiting for [$check ($arglist)] without a timeout"
     fi
     start_ts=$(date +%s)
     while :
     do
-        (echo > /dev/tcp/$HOST/$PORT) >/dev/null 2>&1
+        (eval $check) >/dev/null 2>&1
         result=$?
         if [[ $result -eq 0 ]]; then
             end_ts=$(date +%s)
-            echoerr "$cmdname: $HOST:$PORT is available after $((end_ts - start_ts)) seconds"
+            echoerr "$cmdname: [$check ($arglist)] succeeded after $((end_ts - start_ts)) seconds"
             break
         fi
         sleep 1
@@ -47,17 +52,20 @@ wait_for()
 wait_for_wrapper()
 {
     # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ "$HEALTHCHECK" != "" ]]; then
+        checkoption="--check \"$HEALTHCHECK\""
+    fi
     if [[ $QUIET -eq 1 ]]; then
-        timeout $TIMEOUT $0 --quiet --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+        eval timeout $TIMEOUT $0 --quiet --child --host=$HOST --port=$PORT --timeout=$TIMEOUT $checkoption $custom_args &
     else
-        timeout $TIMEOUT $0 --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+        eval timeout $TIMEOUT $0 --child --host=$HOST --port=$PORT --timeout=$TIMEOUT $checkoption $custom_args &
     fi
     PID=$!
     trap "kill -INT -$PID" INT
     wait $PID
     RESULT=$?
     if [[ $RESULT -ne 0 ]]; then
-        echoerr "$cmdname: timeout occurred after waiting $TIMEOUT seconds for $HOST:$PORT"
+        echoerr "$cmdname: timeout occurred after waiting $TIMEOUT seconds for [$check ($arglist)] to succeed"
     fi
     return $RESULT
 }
@@ -102,6 +110,17 @@ do
         PORT="${1#*=}"
         shift 1
         ;;
+        --arg=*)
+        custom_args="$custom_args $1 $2"
+        argname="${1#*=}"
+        arglist="$arglist $argname=$2"
+        eval "$argname=$2"
+        shift 2
+        ;;
+        --check)
+        HEALTHCHECK="$HEALTHCHECK $2"
+        shift 2
+        ;;
         -t)
         TIMEOUT="$2"
         if [[ $TIMEOUT == "" ]]; then break; fi
@@ -127,9 +146,13 @@ do
 done
 
 if [[ "$HOST" == "" || "$PORT" == "" ]]; then
-    echoerr "Error: you need to provide a host and port to test."
-    usage
+    if [[ "$HEALTHCHECK" == "" ]]; then
+        echoerr "Error: you need to provide a host and port to test."
+        usage
+    fi
 fi
+
+arglist="HOST=$HOST PORT=$PORT $arglist"
 
 TIMEOUT=${TIMEOUT:-15}
 STRICT=${STRICT:-0}


### PR DESCRIPTION
- abstracted healthcheck, with default as currently defined
- additional '--check' cmdline arg to provide command to determine availability
- additional '--arg=NAME' to provide way of configuring additional args
- can be used in conjunction with healthcheck to provide more configurability
- changed result messaging to support showing healthcheck and relevant env vars