### PR TITLE
Add wait_with_expect for systems that don't have timeout (e.g., mac OSX)

### DIFF
--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -44,7 +44,23 @@ wait_for()
     return $result
 }
 
-wait_for_wrapper()
+wait_with_expect()
+{
+    # start the command in a subshell to avoid problem with pipes
+    # (spawn accepts one command)
+    [[ $QUIET -eq 1 ]] && QUIET_ARG="--quiet" || QUIET_ARG=""
+    command="/bin/sh -c \"$0 $QUIET_ARG --child --host=$HOST --port=$PORT --timeout=$TIMEOUT\""
+
+    expect -c "set echo \"-noecho\"; set timeout $TIMEOUT; spawn -noecho $command; expect timeout { exit 1 } eof { exit 0 }"
+    RESULT=$?
+
+    if [[ $RESULT -ne 0 ]]; then
+        echoerr "$cmdname: timeout occurred after waiting $TIMEOUT seconds for $HOST:$PORT"
+    fi
+    return $RESULT
+}
+
+wait_with_timeout()
 {
     # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
     if [[ $QUIET -eq 1 ]]; then
@@ -60,6 +76,18 @@ wait_for_wrapper()
         echoerr "$cmdname: timeout occurred after waiting $TIMEOUT seconds for $HOST:$PORT"
     fi
     return $RESULT
+}
+
+wait_for_wrapper()
+{
+    if type -P timeout &>/dev/null; then
+      wait_with_timeout
+    elif type -P expect &>/dev/null; then
+      wait_with_expect
+    else
+      echo >&2 echo "Neither timeout nor expect available."
+      exit 2;
+    fi
 }
 
 # process arguments


### PR DESCRIPTION
The version of bash on Mac OSX doesn't have `timeout` installed by default. We can, however, get the same functionality using `expect`. This pull requests adds support for Mac by testing for the existence of the appropriate command to implement the timeout functionality.

RESULT:
 * If the `timeout` command exists, everything works as before.
 * If the`timeout` command does **not** exist, but the `expect` command does exist, the same functionality will work (including handling SIGINT) using `expect`.
 * If neither `timeout` nor `expect` commands exist, we will fail with an appropriate error message and exit code.

 