### PR TITLE
Fix handling of parameters with spaces

### DIFF
--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -118,7 +118,6 @@ do
         ;;
         --)
         shift
-        CLI="$@"
         break
         ;;
         --help)
@@ -166,12 +165,12 @@ else
     fi
 fi
 
-if [[ $CLI != "" ]]; then
+if [[ $# > 0 ]]; then
     if [[ $RESULT -ne 0 && $STRICT -eq 1 ]]; then
         echoerr "$cmdname: strict mode, refusing to execute subprocess"
         exit $RESULT
     fi
-    exec $CLI
+    exec "$@"
 else
     exit $RESULT
 fi


### PR DESCRIPTION
If parameters are enclosed in " and contain spaces they can only
be passed on properly if the quoting is handled correctly. This can
be done for example by using "$@" in all places. Simply assigning
"$@" to a varible and using that variable will break the quoting.
For example "1" "2 2" will become "1 2 2" or 1 2 3 depending on what you
do.