### PR TITLE
fix: preserve quotation when passing arguments to command.

### DIFF
--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -118,7 +118,7 @@ do
         ;;
         --)
         shift
-        CLI="$@"
+        CLI=("$@")
         break
         ;;
         --help)
@@ -171,7 +171,7 @@ if [[ $CLI != "" ]]; then
         echoerr "$cmdname: strict mode, refusing to execute subprocess"
         exit $RESULT
     fi
-    exec $CLI
+    exec "${CLI[@]}"
 else
     exit $RESULT
 fi


### PR DESCRIPTION
Fix to preserve quotation when passing argument to the command. 
$CLI should be treated as an array rather than string.