### PR TITLE
windows docker fix

### DIFF
--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -118,7 +118,7 @@ do
         ;;
         --)
         shift
-        CLI=("$@")
+        CLI="$@"
         break
         ;;
         --help)
@@ -171,7 +171,7 @@ if [[ $CLI != "" ]]; then
         echoerr "$cmdname: strict mode, refusing to execute subprocess"
         exit $RESULT
     fi
-    exec "${CLI[@]}"
+    exec $CLI
 else
     exit $RESULT
 fi


### PR DESCRIPTION
running command like this will make it work on windows
command: bash -c "sed -i 's/\r//g' ./wait-for-it.sh && bash ./wait-for-it.sh -t 120 db:3306 -- npm start"