### PR TITLE
fix `which: command not found`

### DIFF
--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -143,7 +143,7 @@ QUIET=${QUIET:-0}
 
 # check to see if timeout is from busybox?
 # check to see if timeout is from busybox?
-TIMEOUT_PATH=$(realpath $(which timeout))
+TIMEOUT_PATH=$(realpath $(command -v timeout))
 if [[ $TIMEOUT_PATH =~ "busybox" ]]; then
         ISBUSY=1
         BUSYTIMEFLAG="-t"


### PR DESCRIPTION
Some system do not have the `which` command.

See https://unix.stackexchange.com/a/85250/48395