### PR TITLE
Avoid sending a newline character which confuses servers.

### DIFF
--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -36,7 +36,7 @@ wait_for()
             nc -z $WAITFORIT_HOST $WAITFORIT_PORT
             WAITFORIT_result=$?
         else
-            (echo > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+            (echo -n > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
             WAITFORIT_result=$?
         fi
         if [[ $WAITFORIT_result -eq 0 ]]; then


### PR DESCRIPTION
echo sends a newline character which causes some server software to report an error message about an invalid HTTP request. By adding the '-n' flag the echo command can be used to open the port without sending anything.