### PR TITLE
Add a timeout on connecting to a TCP device

### DIFF
--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -36,7 +36,7 @@ wait_for()
             nc -z $WAITFORIT_HOST $WAITFORIT_PORT
             WAITFORIT_result=$?
         else
-            (echo > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+            timeout 1 bash -c "(echo > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1"
             WAITFORIT_result=$?
         fi
         if [[ $WAITFORIT_result -eq 0 ]]; then


### PR DESCRIPTION
In our setup (running inside docker), opening a connection to a TCP device has a long timeout (128 seconds). That means that the script will start by trying to connect to the device. If this is not immediately succesful, it takes 128 for the command to fail. So if the device is actualy available after 10 seconds, we wait 118 seconds too much.

This setting is defined in the source, and is is not possible to change this timeout in bash. A workaround is to add a timeout to the command attempting a connection to the device.

This solution is based on https://stackoverflow.com/a/40158514