### PR TITLE
Publish to PHP Composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 **/*.pyc
 .pydevproject
-
+/vendor/

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,7 @@
+{
+    "name": "vishnubob/wait-for-it",
+    "description": "Pure bash script to test and wait on the availability of a TCP host and port",
+    "type": "library",
+    "license": "MIT",
+    "bin": ["wait-for-it.sh"]
+}


### PR DESCRIPTION
It will allow PHP projects to install `wait-for-it.sh` through its natural dependency manager. 

```bash
composer require --dev vishnubob/wait-for-it@dev
```