### PR TITLE
Append license to file header

### DIFF
--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -1,5 +1,33 @@
 #!/usr/bin/env bash
+#
+# wait-for-it.sh
+#
 # Use this script to test if a given TCP host/port are available
+#
+# Homepage: https://github.com/vishnubob/wait-for-it
+
+# License:
+#
+# The MIT License (MIT)
+# Copyright (c) 2016 Giles Hall
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 
 WAITFORIT_cmdname=${0##*/}
 


### PR DESCRIPTION
This is useful so that folks can copy the script file into their own projects and have the license intact.

I also added the project homepage so that folks know where it came from and where to go to look for updates.

This is a variation on https://github.com/vishnubob/wait-for-it/pull/42 that is updated to work with the latest `master` branch.

Closes: #42