### PR TITLE
Add --reverse flag to wait until the port is no longer available

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ wait-for-it.sh host:port [-s] [-t timeout] [-- command args]
 -h HOST | --host=HOST       Host or IP under test
 -p PORT | --port=PORT       TCP port under test
                             Alternatively, you specify the host and port as host:port
+-r | --reverse              Perform the reverse test, wait until a port is
+                            no longer available
 -s | --strict               Only execute subcommand if the test succeeds
 -q | --quiet                Don't output any status messages
 -t TIMEOUT | --timeout=TIMEOUT
@@ -34,6 +36,15 @@ $ ./wait-for-it.sh -t 0 www.google.com:80 -- echo "google is up"
 wait-for-it.sh: waiting for www.google.com:80 without a timeout
 wait-for-it.sh: www.google.com:80 is available after 0 seconds
 google is up
+```
+
+You can perform the reverse test with the `-r` or `--reverse` option.  Setting the reverse flag will check if the port is unavailable and if it is, echo the message `port is unavailable`.
+
+```
+$ ./wait-for-it.sh localhost:0 --reverse -- echo "port is unavailable"
+wait-for-it.sh: waiting 15 seconds for localhost:0
+wait-for-it.sh: localhost:0 is unavailable after 0 seconds
+port is unavailable
 ```
 
 The subcommand will be executed regardless if the service is up or not.  If you wish to execute the subcommand only if the service is up, add the `--strict` argument. In this example, we will test port 81 on www.google.com which will fail:

--- a/test/wait-for-it.py
+++ b/test/wait-for-it.py
@@ -113,6 +113,17 @@ class TestWaitForIt(unittest.TestCase):
         )
         soc.close()
 
+    def test_reverse_host_port(self):
+        """ Check that --reverse args work correctly """
+        soc, port = self.open_local_port()
+        soc.close()
+        self.check_args(
+            "--host=localhost --port={0} --timeout=1 --reverse".format(port),
+            "",
+            ".*wait-for-it.sh: localhost:{0} is unavailable after 0 seconds".format(port),
+            True
+        )
+
     def test_combined_host_port(self):
         """
             Tests that wait-for-it.sh returns correctly after establishing a
@@ -130,7 +141,7 @@ class TestWaitForIt(unittest.TestCase):
 
     def test_port_failure_with_timeout(self):
         """
-            Note exit status of 124 is exected, passed from the timeout command
+            Note exit status of 124 is expected, passed from the timeout command
         """
         self.check_args(
             "localhost:8929 --timeout=1",

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -50,7 +50,7 @@ wait_for()
         fi
         sleep 1
     done
-    return $WAITFORIT_result
+    return $([[ $WAITFORIT_result -eq $WAITFORIT_test_success ]] && echo 0 || echo 1)
 }
 
 wait_for_wrapper()

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -13,7 +13,7 @@ Usage:
     -h HOST | --host=HOST       Host or IP under test
     -p PORT | --port=PORT       TCP port under test
                                 Alternatively, you specify the host and port as host:port
-    -r | --reverse              Perform reverse test, wait until a port is
+    -r | --reverse              Perform the reverse test, wait until a port is
                                 no longer available
     -s | --strict               Only execute subcommand if the test succeeds
     -q | --quiet                Don't output any status messages


### PR DESCRIPTION
This program is great at waiting for a service to become available, especially when we are coordinating programs that depend on network resources. Conversely, said programs sometimes need to wait for network resources to be closed or unavailable in order to shutdown gracefully.

This is where the `--reverse` flag comes in, it reverses the test that is being performed on the network resource. Allowing for the use case above to work.

This Pull Request also adds the accompanying test case.
