### PR TITLE
Added two more options - wait time and also command to use for testing

### DIFF
--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -15,7 +15,8 @@ Usage:
                                 Alternatively, you specify the host and port as host:port
     -c COMMAND | --command=COMMAND 
                                 A single command to test
-    -w TIMEOUT | --wait=TIMEOUT Wait / sleep time between each test attempt
+    -i TIMEOUT | --interval=TIMEOUT
+                                Wait / sleep time interval between each test attempt
     -s | --strict               Only execute subcommand if the test succeeds
     -q | --quiet                Don't output any status messages
     -t TIMEOUT | --timeout=TIMEOUT
@@ -102,12 +103,12 @@ do
         WAITFORIT_COMMAND="${1#*=}"
         shift 1
         ;;
-        -w)
+        -i)
         WAITFORIT_SLEEP_TIME="$2"
         if [[ $WAITFORIT_SLEEP_TIME == "" ]]; then break; fi
         shift 2
         ;;
-        --wait=*)
+        --interval=*)
         WAITFORIT_SLEEP_TIME="${1#*=}"
         shift 1
         ;;

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -13,6 +13,9 @@ Usage:
     -h HOST | --host=HOST       Host or IP under test
     -p PORT | --port=PORT       TCP port under test
                                 Alternatively, you specify the host and port as host:port
+    -c COMMAND | --command=COMMAND 
+                                A single command to test
+    -w TIMEOUT | --wait=TIMEOUT Wait / sleep time between each test attempt
     -s | --strict               Only execute subcommand if the test succeeds
     -q | --quiet                Don't output any status messages
     -t TIMEOUT | --timeout=TIMEOUT
@@ -32,19 +35,28 @@ wait_for()
     WAITFORIT_start_ts=$(date +%s)
     while :
     do
-        if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
-            nc -z $WAITFORIT_HOST $WAITFORIT_PORT
+        if [[ $WAITFORIT_COMMAND != "" ]]; then
+            echoerr "Testing command $WAITFORIT_COMMAND"
+            $WAITFORIT_COMMAND
             WAITFORIT_result=$?
         else
-            (echo -n > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
-            WAITFORIT_result=$?
+            if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
+                echoerr "Testing on busybox against $WAITFORIT_HOST/$WAITFORIT_PORT"
+                nc -z $WAITFORIT_HOST $WAITFORIT_PORT
+                WAITFORIT_result=$?
+            else
+                echoerr "Testing against $WAITFORIT_HOST/$WAITFORIT_PORT"
+                (echo -n > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+                WAITFORIT_result=$?
+            fi
         fi
         if [[ $WAITFORIT_result -eq 0 ]]; then
             WAITFORIT_end_ts=$(date +%s)
             echoerr "$WAITFORIT_cmdname: $WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
             break
         fi
-        sleep 1
+        sleep $WAITFORIT_SLEEP_TIME
+        echoerr "Sleeping for $WAITFORIT_SLEEP_TIME"
     done
     return $WAITFORIT_result
 }
@@ -53,9 +65,9 @@ wait_for_wrapper()
 {
     # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
     if [[ $WAITFORIT_QUIET -eq 1 ]]; then
-        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --command=$WAITFORIT_COMMAND --timeout=$WAITFORIT_TIMEOUT &
     else
-        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --command=$WAITFORIT_COMMAND --timeout=$WAITFORIT_TIMEOUT &
     fi
     WAITFORIT_PID=$!
     trap "kill -INT -$WAITFORIT_PID" INT
@@ -79,6 +91,24 @@ do
         ;;
         --child)
         WAITFORIT_CHILD=1
+        shift 1
+        ;;
+        -c)
+        WAITFORIT_COMMAND="$2"
+        if [[ $WAITFORIT_COMMAND == "" ]]; then break; fi
+        shift 2
+        ;;
+        --command=*)
+        WAITFORIT_COMMAND="${1#*=}"
+        shift 1
+        ;;
+        -w)
+        WAITFORIT_SLEEP_TIME="$2"
+        if [[ $WAITFORIT_SLEEP_TIME == "" ]]; then break; fi
+        shift 2
+        ;;
+        --wait=*)
+        WAITFORIT_SLEEP_TIME="${1#*=}"
         shift 1
         ;;
         -q | --quiet)
@@ -131,8 +161,8 @@ do
     esac
 done
 
-if [[ "$WAITFORIT_HOST" == "" || "$WAITFORIT_PORT" == "" ]]; then
-    echoerr "Error: you need to provide a host and port to test."
+if [[ ("$WAITFORIT_HOST" == "" || "$WAITFORIT_PORT" == "") &&  "$WAITFORIT_COMMAND" == "" ]]; then
+    echoerr "Error: you need to provide a host and port, or a single command to test."
     usage
 fi
 


### PR DESCRIPTION
Added two more options to the script - First is 'wait time', which allows to specify time interval between each polling - previously it was hardcoded to 1 sec. Second option is 'command' - this allows you to test not only for port being open, but also to execute some testing command / script. For example, you might want to wait, until a REST API server becomes alive - you can have a script that makes calls to this server in order to check if it is alive and with the new option you can call this script and wait until it returns success as return code. Here is some sample usage in ENTRYPOINT: ENTRYPOINT [./wait-for-it.sh, -t, 0, -w, 60, -c, ./check_if_api_is_alive.sh, --, npm, start]. And here is how 'check_if_api_is_alive.sh' script might look like - 'curl --fail --silent localhost:8888/application/health | grep UP || exit 1'
Also added some message printing during the script operation in order to improve its usability / troubleshooting.