### PR TITLE
Use nc command if it exists and specify explicit connection timeout to avoid hanging

### DIFF
--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -36,7 +36,7 @@ wait_for()
             nc -z -w 10 $WAITFORIT_HOST $WAITFORIT_PORT
             WAITFORIT_result=$?
         else
-            (echo -n > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+            timeout 10 bash -c "(echo -n > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1"
             WAITFORIT_result=$?
         fi
         if [[ $WAITFORIT_result -eq 0 ]]; then

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -32,8 +32,8 @@ wait_for()
     WAITFORIT_start_ts=$(date +%s)
     while :
     do
-        if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
-            nc -z $WAITFORIT_HOST $WAITFORIT_PORT
+        if command -v nc &> /dev/null ; then
+            nc -z -w 10 $WAITFORIT_HOST $WAITFORIT_PORT
             WAITFORIT_result=$?
         else
             (echo -n > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1


### PR DESCRIPTION
Use _nc_ command if it exists.

Add explicit connection timeout of 10 seconds, because, depending on the system, _nc_ command could be a symlink to _netcat_ or _Ncat_ program (a netcat re-implementation), and _Ncat_ has a default connection timeout od 10 seconds (thus this value was chosen), while _netcat_ has infinite connection timeout by default. Infinite connection timeout resulted in _wait-for-it.sh_ to hang and never succeed to connect to target host if it wasn't reachable initially but became reachable a bit later (for example when starting docker containers), until main wait-for-it.sh timeout expired, at which point it is too late.

The same timeout value of 10 seconds is also added to network redirection for the same reason.